### PR TITLE
SHARD-999 npm migration use github instead of npm for shardus packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@shardeum-foundation/archiver-discovery",
+  "name": "@shardus/archiver-discovery",
   "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@shardeum-foundation/archiver-discovery",
+      "name": "@shardus/archiver-discovery",
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@shardeum-foundation/crypto-utils": "4.1.3",
+        "@shardus/crypto-utils": "git+https://github.com/shardeum/lib-crypto-utils#v4.1.3",
         "axios": "1.6.1",
         "gts": "3.1.1"
       },
@@ -1286,12 +1286,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/@shardeum-foundation/crypto-utils": {
+    "node_modules/@shardus/crypto-utils": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/crypto-utils/-/crypto-utils-4.1.3.tgz",
-      "integrity": "sha512-TvdZn/9VwlAHsx4EJV8aUo8vt5eRSZm12DPP/Gfl/fchs1PIBxyWYg0uChLLMsLTbyhYNW8LFqbTSbsmyuOs7g==",
+      "resolved": "git+ssh://git@github.com/shardeum/lib-crypto-utils.git#71434565c9b73500d81f1f44e88ac6738fe0d662",
+      "license": "ISC",
       "dependencies": {
-        "@shardeum-foundation/types": "1.2.8",
+        "@shardus/types": "1.2.8",
         "buffer-xor": "2.0.2",
         "fast-stable-stringify": "1.0.0",
         "sodium-native": "3.3.0"
@@ -1300,10 +1300,10 @@
         "node": "18.16.1"
       }
     },
-    "node_modules/@shardeum-foundation/types": {
+    "node_modules/@shardus/types": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@shardeum-foundation/types/-/types-1.2.8.tgz",
-      "integrity": "sha512-wBUUd9Q4pbvYe5MbAvC+2SD0cHZGsVKiDBHw42/DM3eZZOu4Jnzxig/wAJDNfPzuyrTtwi/izsuAlesJ5HNFTA=="
+      "resolved": "https://registry.npmjs.org/@shardus/types/-/types-1.2.8.tgz",
+      "integrity": "sha512-QCCHm15dmEFkH+TUMUNMT/iCGCsjOR8z6/5AZasG7Gsu9CTL85V4L+Ny/SGjKzM9sdi1Vz8XARy96r+slUZBOg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shardeum-foundation/archiver-discovery",
+  "name": "@shardus/archiver-discovery",
   "version": "1.1.0",
   "description": "Archiver sudo auto discovery module",
   "main": "./dist/src/index.js",
@@ -24,15 +24,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://gitlab.com/shardeum/archiver-discovery.git"
+    "url": "https://github.com/shardeum/lib-archiver-discovery"
   },
   "publishConfig": {
     "access": "public"
   },
   "bugs": {
-    "url": "https://gitlab.com/shardus/archiver-discovery/issues"
+    "url": "https://github.com/shardeum/lib-archiver-discovery/issues"
   },
-  "homepage": "https://gitlab.com/shardus/archiver-discovery#readme",
+  "homepage": "https://github.com/shardeum/lib-archiver-discovery#readme",
   "devDependencies": {
     "@types/jest": "29.5.0",
     "@types/node": "18.16.1",
@@ -48,7 +48,7 @@
     "typescript": "5.0.2"
   },
   "dependencies": {
-    "@shardeum-foundation/crypto-utils": "4.1.3",
+    "@shardus/crypto-utils": "git+https://github.com/shardeum/lib-crypto-utils#v4.1.3",
     "axios": "1.6.1",
     "gts": "3.1.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as crypto from '@shardeum-foundation/crypto-utils'
+import * as crypto from '@shardus/crypto-utils'
 import { AxiosRequestConfig } from 'axios'
 import { readConfigFromFile, removeDuplicateArchiversByPubKey, sanitizeArchiverList } from './helpers'
 import {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Signature } from '@shardeum-foundation/crypto-utils'
+import { Signature } from '@shardus/crypto-utils'
 
 export interface Archiver {
   ip: string


### PR DESCRIPTION
this also reverts back to the current package name, that will be done in a second pass